### PR TITLE
fix: 修复指令`unbind`时存在的空指针问题

### DIFF
--- a/src/directive.ts
+++ b/src/directive.ts
@@ -51,6 +51,11 @@ const unbind = (
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const contextmenuInstance: any = binding.instance?.$refs[contextmenuKey];
 
+  if (!contextmenuInstance) {
+    console.error(`没有找到 ${contextmenuKey} 对应的实例`);
+    return;
+  }
+
   if (typeof contextmenuInstance.removeReference !== 'function') {
     console.error(`${contextmenuKey} 对应的实例不是 VContextmenu`);
     return;


### PR DESCRIPTION
## 描述
当 v-contextmenu 指令用在 KeepAlive 的子组件中时，指令`unbind`过程中， contextmenuInstance 为 undefined 时，需要拦截。

## 类型

- [x] 修复 bug（没有不兼容的修改）
- [ ] 新功能（没有不兼容的修改）
- [ ] 不兼容的修改（修复 bug 或者新增功能时导致现有版本不能正常工作）

## 请确保已完成以下内容

- [x] 代码风格与本项目一致，并通过 `npm run lint` 校验
- [x] 如果需要修改文档，请修改（包含中英文文档）
- [x] 遵循 [Semantic Versioning 2.0.0](https://semver.org/) 修改版本号