### PR TITLE
fix: 增加 contextmenu 的空检查

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -4,12 +4,16 @@ export default {
   bind (el, binding, vnode) {
     const node = vnode.context.$refs[binding.arg] || vnode.context.$refs[binding.value]
     const contextmenu = Object.prototype.toString.call(node) === '[object Array]' ? node[0] : node
-    contextmenu.$contextmenuId = el.id || contextmenu._uid // eslint-disable-line no-underscore-dangle
+    if (contextmenu) {
+      contextmenu.$contextmenuId = el.id || contextmenu._uid // eslint-disable-line no-underscore-dangle
+    }
   },
   // 之所以用 inserted 而不是 bind，是需要确保 contentmenu mounted 后才进行 addRef 操作
   inserted (el, binding, vnode) {
     const node = vnode.context.$refs[binding.arg] || vnode.context.$refs[binding.value]
     const contextmenu = Object.prototype.toString.call(node) === '[object Array]' ? node[0] : node
-    contextmenu.addRef({ el, vnode })
+    if (contextmenu) {
+      contextmenu.addRef({ el, vnode })
+    }
   },
 }


### PR DESCRIPTION
<!-- 本页注释可任意删除 -->

## 描述

修复了在下述场景下出现运行时报错的问题

```vue
<template>
    <div>
        <v-contextmenu v-if="showContextmenu" ref="contextmenu">
            <v-contextmenu-item>菜单1</v-contextmenu-item>
            <v-contextmenu-item>菜单2</v-contextmenu-item>
            <v-contextmenu-item>菜单3</v-contextmenu-item>
        </v-contextmenu>
        <div v-contextmenu:contextmenu>右键点击此区域</div>
    </div>
</template>

<script lang="ts">
import { defineComponent } from 'vue';

export default defineComponent({
    props: {
        showContextmenu: {
            type: Boolean,
            default: false,
        },
    },
});
</script>
```

将出现下面的报错

<img width="855" alt="image" src="https://github.com/CyberNika/v-contextmenu/assets/22289445/24a820ad-6517-4afc-b12c-e7b02967eb4a">


## 操作

增加 contextmenu 的空检查

## 类型

- [x] 修复 bug（没有不兼容的修改）
- [ ] 新功能（没有不兼容的修改）
- [ ] 不兼容的修改（修复 bug 或者新增功能时导致现有版本不能正常工作）

## 请确保已完成以下内容

- [x] 代码风格与本项目一致，并通过 `npm run lint` 校验
- [x] 如果需要修改文档，请修改（包含中英文文档）
- [x] 遵循 [Semantic Versioning 2.0.0](https://semver.org/) 修改版本号
